### PR TITLE
Add protocol and wiring documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
 # WIFIRover
+
+WIFIRover is a Wi-Fi enabled rover platform that combines an ESP32-based
+handheld controller, an onboard ESP32 Wi-Fi hub, and multiple Arduino Nanos to
+control drivetrain actuators and collect telemetry. The sketches in this
+repository provide a starting point for assembling the full system or for
+studying each subsystem in isolation.
+
+## Project Highlights
+- **Wireless control** – The controller ESP32 connects to the rover's onboard
+  ESP32 access point and streams joystick, throttle, and accessory commands over
+  UDP at 10 Hz.
+- **Modular managers** – Dedicated Arduino Nanos handle vehicle actuation and
+  environment sensing, allowing the Wi-Fi hub to focus on networking and
+  failsafe logic.
+- **Telemetry feedback** – Sensor data is forwarded to the controller and shown
+  on a TFT display, while a standalone speed monitoring sketch visualises motion
+  on an OLED.
+
+## Repository Layout
+| File / Folder | Purpose |
+| --- | --- |
+| `ControllerWifiSimplified.ino` | Firmware for the handheld ESP32 controller with TFT UI. |
+| `MCUwifiSimplified.ino` | ESP32 access-point firmware that bridges Wi-Fi to dual UARTs. |
+| `VehicleManager.ino` | Arduino Nano sketch controlling servos, ESC, horn, and lights. |
+| `SensorManager.ino` | Arduino Nano sketch that streams environment telemetry (currently simulated). |
+| `SpeedSensor.ino` | Optional module measuring wheel speed and distance with a hall sensor. |
+| `docs/communication_protocol.md` | Detailed description of command packets and telemetry framing. |
+| `docs/wiring_schema.md` | Pinout reference and wiring guidelines for all modules. |
+
+## Getting Started
+1. **Prepare the hardware**
+   - Assemble the rover electronics following the wiring guidelines in
+     [`docs/wiring_schema.md`](docs/wiring_schema.md).
+   - Ensure all boards share a common ground and that the power delivery can
+     supply servos/ESC current peaks.
+2. **Flash the firmware**
+   - Upload each sketch to its respective board (controller ESP32, robot ESP32,
+     Vehicle Manager Nano, Sensor Manager Nano, and optional speed sensor
+     module).
+   - Confirm serial baud rates match the sketches (115200 bps for all inter-board
+     links except the speed sensor at 9600 bps).
+3. **Establish the network link**
+   - Power the robot ESP32 to start the `Robot_AP` access point (password
+     `12345678`).
+   - Power the controller ESP32; it will connect to the AP automatically and
+     begin transmitting command packets every 100 ms.
+4. **Verify operation**
+   - Watch the Vehicle Manager servos/ESC respond to joystick inputs.
+   - Check that telemetry values appear on the controller TFT, confirming the
+     Sensor Manager and Wi-Fi bridge are operating.
+   - (Optional) Monitor averaged speed and distance on the OLED if the speed
+     sensor module is installed.
+
+## Communication and Telemetry
+The command string format, failsafe behaviour, and telemetry framing are fully
+documented in [`docs/communication_protocol.md`](docs/communication_protocol.md).
+Consult that guide when integrating new sensors or extending the command set.
+
+## Contributing
+Pull requests and issue reports are welcome. Please include relevant wiring
+notes and protocol updates in the documentation when modifying the sketches.

--- a/docs/communication_protocol.md
+++ b/docs/communication_protocol.md
@@ -1,0 +1,110 @@
+# Command and Communication Protocols
+
+## System Overview
+The WIFIRover platform is composed of four microcontroller roles that cooperate over
+Wi-Fi and serial links:
+
+1. **Handheld Controller (ESP32 + TFT)** – Reads joystick and button inputs and
+   sends driving commands over UDP while rendering telemetry on the TFT screen.
+2. **Robot Wi-Fi Hub (ESP32)** – Hosts the Wi-Fi access point, relays control
+   commands to the vehicle electronics, forwards telemetry back to the
+   controller, and enforces a failsafe.
+3. **Vehicle Manager (Arduino Nano)** – Drives the steering servos, electronic
+   speed controller (ESC), horn, and lighting system based on commands received
+   from the Wi-Fi hub.
+4. **Sensor Manager (Arduino Nano)** – Streams distance, temperature, and
+   humidity readings to the Wi-Fi hub, which are then sent to the controller.
+
+An optional **Speed Sensor module** (standalone sketch) reports average speed and
+travelled distance on an OLED display and the serial monitor.
+
+```
+[Controller ESP32] ⇄ Wi-Fi UDP ⇄ [Robot ESP32] ⇄ UART1 ⇄ [Sensor Nano]
+                                            ⇓ UART2
+                                         [Vehicle Nano]
+```
+
+## Wi-Fi Transport Layer
+- **Network SSID:** `Robot_AP`
+- **Passphrase:** `12345678`
+- **Mode:** The robot ESP32 starts an access point; the controller connects as a
+  station.
+- **UDP Port:** `4210` for both transmission directions.
+- **Send Interval:** The controller transmits a control packet every 100 ms.
+
+## Controller → Robot Control Packets
+The controller concatenates multiple command tokens into a single ASCII string
+before transmitting it via UDP:
+
+```
+CMD STEER <value>;CMD THROT <value>;CMD HORN <0|1>;CMD LIGHTS <0|1>;
+```
+
+| Token | Description | Value range / meaning |
+| --- | --- | --- |
+| `CMD STEER`  | Front/rear steering command mapped from the joystick X axis. | `-90` (full left) to `90` (full right) |
+| `CMD THROT`  | Throttle command mapped from the joystick Y axis. | `-100` (full reverse) to `100` (full forward) |
+| `CMD HORN`   | Horn push-button state. | `0` = off, `1` = on |
+| `CMD LIGHTS` | Latched auxiliary lighting state. | `0` = off, `1` = on |
+
+Each packet is terminated with a newline before being forwarded to the Vehicle
+Manager over UART.
+
+### Robot → Vehicle Serial Framing
+The robot ESP32 forwards the UDP payload without modification to the Vehicle
+Manager Nano (followed by `\n`). The Vehicle Manager parses tokens separated by
+semicolons (`;`) and expects the prefix shown above. Additional tokens can be
+introduced by following the `CMD <NAME> <value>;` convention.
+
+### Failsafe Handling
+- The robot ESP32 tracks the arrival time of UDP packets. If no packet arrives
+  within 1 second it sends a `CMD FAILSAFE` newline-terminated message to the
+  Vehicle Manager and sets an internal failsafe flag.
+- The Vehicle Manager implements an additional watchdog. If it does not process
+  any serial input for 500 ms it reverts steering and throttle to neutral (90°
+  servo position/ESC idle) and clears horn/lights/autonomous flags.
+
+## Sensor Telemetry Stream
+The Sensor Manager Nano emits a telemetry frame every 500 ms using the format:
+
+```
+S:<front>,<frontLeft>,<frontRight>,<left>,<right>,<temperature>,<humidity>;
+```
+
+All fields are integers representing centimetres for distance values, degrees
+Celsius for temperature, and percentage for relative humidity. Example:
+
+```
+S:100,95,102,85,90,25,50;
+```
+
+The robot ESP32 reads newline-terminated frames from the sensor UART, forwards
+complete lines to the controller via UDP, and mirrors them to its serial console
+for debugging.
+
+### Controller Telemetry Rendering
+The controller searches the incoming telemetry string for the first colon, then
+extracts comma-separated values and displays them on the TFT display in the
+following order:
+
+1. Front distance (`F`)
+2. Front-left distance (`FL`)
+3. Front-right distance (`FR`)
+4. Left side distance (`L`)
+5. Right side distance (`R`)
+6. Temperature (`T`)
+7. Humidity (`H`)
+
+Values are labelled and units appended (`cm`, `C`, `%`).
+
+## Speed Sensor Telemetry (Standalone)
+The `SpeedSensor.ino` sketch samples a hall-effect wheel sensor on digital pin 2
+and reports:
+
+- Raw and averaged linear speed (in m/s) on the serial monitor.
+- Total distance travelled (in metres).
+- Averaged speed and distance on a 128×64 OLED display addressed at I²C `0x3C`.
+
+The distance per pulse is set to 4.04 cm (derived from the measured wheel
+circumference and magnet configuration). A rolling average of the last five
+samples smooths the reported speed.

--- a/docs/wiring_schema.md
+++ b/docs/wiring_schema.md
@@ -1,0 +1,99 @@
+# Wiring Schema
+
+This document captures the wiring expectations encoded in the Arduino sketches.
+It focuses on pin assignments, power domains, and serial links so you can
+reproduce the hardware layout when assembling the WIFIRover platform.
+
+## Overall Topology
+```
+[ESP32 Controller] ⇄ Wi-Fi UDP ⇄ [ESP32 Robot Hub]
+                                           ↘ UART2 ⇄ Vehicle Nano
+                                            ↘ UART1 ⇄ Sensor Nano
+```
+
+- The **controller ESP32** is battery powered and drives a TFT_eSPI display,
+  joystick, and two momentary buttons.
+- The **robot ESP32** is chassis-mounted, supplies regulated 5 V to the Arduino
+  Nanos, and bridges Wi-Fi to two independent UARTs.
+- The **Vehicle Manager Nano** actuates the steering servos, ESC, horn relay, and
+  auxiliary lights.
+- The **Sensor Manager Nano** aggregates distance, temperature, and humidity
+  sensors and streams telemetry.
+
+> ⚠️ *Always share a common ground between every board and peripheral.*
+
+## Controller ESP32 (Handheld)
+| Function            | ESP32 Pin | Notes |
+|---------------------|-----------|-------|
+| Joystick X (ADC)    | 34        | Connect wiper to pin 34, ends to 3.3 V and GND. |
+| Joystick Y (ADC)    | 35        | Same wiring as X axis. |
+| Button 1 (horn)     | 0         | Uses `INPUT_PULLUP`; connect button to ground. |
+| Button 2 (lights)   | 2         | Uses `INPUT_PULLUP`; connect button to ground. |
+| TFT display         | SPI pins  | Follows [TFT_eSPI](https://github.com/Bodmer/TFT_eSPI) default wiring for your board profile. |
+
+Power the controller from a 3.3 V capable supply or LiPo pack via the ESP32's
+regulated input. The joystick potentiometer and buttons operate at 3.3 V logic.
+
+## Robot ESP32 (Wi-Fi Hub)
+| Connection                      | ESP32 Pin | Destination                | Notes |
+|---------------------------------|-----------|----------------------------|-------|
+| UART to Sensor Manager (RX)     | 18        | Nano D1 (TX)               | HardwareSerial 1 RX. |
+| UART to Sensor Manager (TX)     | 19        | Nano D0 (RX)               | HardwareSerial 1 TX. |
+| UART to Vehicle Manager (RX)    | 16        | Nano D1 (TX)               | HardwareSerial 2 RX. |
+| UART to Vehicle Manager (TX)    | 17        | Nano D0 (RX)               | HardwareSerial 2 TX. |
+| Power output (recommended)      | 5 V / GND | Both Nanos + sensors       | Use a regulated 5 V rail rated for the servos. |
+
+> 🔁 **Cross the serial wires:** ESP32 TX → Nano RX, ESP32 RX ← Nano TX.
+
+Because the ESP32 operates at 3.3 V logic and the Nanos at 5 V, ensure your
+hardware uses level shifters or Nanos tolerant to 3.3 V inputs. For short runs
+most builders successfully drive ESP32 RX pins directly from the Nano using a
+voltage divider (e.g. 1 kΩ / 2 kΩ) or a logic-level converter.
+
+## Vehicle Manager Nano
+| Function                 | Nano Pin | Target hardware                         |
+|--------------------------|----------|------------------------------------------|
+| Serial from ESP32 (RX)   | D0 (RX)  | Receive `CMD ...` frames from robot ESP32. |
+| Serial to ESP32 (TX)     | D1 (TX)  | Echoes optional debug, unused by default. |
+| Front steering servo     | D10      | Standard 3-pin servo header (signal on D10). |
+| Rear steering servo      | D11      | Standard 3-pin servo header (signal on D11). |
+| ESC signal               | D12      | Connect signal wire from ESC.            |
+| Horn driver              | D13      | Drives a MOSFET/transistor controlling the horn. |
+| Auxiliary lights         | D9       | Switches LED bar or lighting relay.      |
+| 5 V / GND                | 5 V, GND | Shared with servos, ESC BEC, horn relay, lights. |
+
+Servos and ESCs can draw significant current; route their +5 V supply directly
+from the BEC or a dedicated regulator and only share the ground reference with
+the Nano. The sketch expects standard hobby ESC and servo PWM pulses (typically
+1–2 ms at ~50 Hz, generated via the Servo library).
+
+## Sensor Manager Nano
+The sample sketch currently simulates sensor data, but the pin usage is intended
+for a suite of ultrasonic rangefinders and an environmental sensor:
+
+| Function               | Suggested Pins | Notes |
+|------------------------|----------------|-------|
+| Serial to ESP32 (TX)   | D1 (TX)        | Streams telemetry frames at 115200 bps. |
+| Serial from ESP32 (RX) | D0 (RX)        | Reserved if future commands are added. |
+| Ultrasonic sensors     | D2–D7          | Allocate trigger/echo pairs per sensor. |
+| Temperature/humidity   | A4 (SDA), A5 (SCL) | For I²C sensors such as the DHT20/HTU21. |
+| 5 V / GND              | 5 V, GND       | Shared with the robot ESP32 supply. |
+
+Adapt pin choices to match the actual sensors you deploy, ensuring the telemetry
+format documented in [`communication_protocol.md`](communication_protocol.md) is
+maintained.
+
+## Speed Sensor Module (Standalone)
+If you deploy the speed sensor monitor (`SpeedSensor.ino`), wire the components
+as follows:
+
+| Function               | Arduino Pin | Notes |
+|------------------------|-------------|-------|
+| Hall effect sensor     | D2          | Uses an interrupt on the rising edge. Enable pull-up if the sensor is open drain. |
+| OLED SDA               | A4 (SDA)    | Default I²C data line on Arduino Uno/Nano. |
+| OLED SCL               | A5 (SCL)    | Default I²C clock line. |
+| OLED VCC / GND         | 5 V, GND    | The SSD1306 module typically accepts 3.3–5 V. |
+
+Mount four magnets evenly around the drivetrain shaft so the sensor registers
+four pulses per revolution. Adjust the `distancePerPulse` constant if your wheel
+circumference or magnet count differs from the example configuration.


### PR DESCRIPTION
## Summary
- add a command and communication protocol reference for the ESP32 and Nano coordination
- document the wiring schema covering pinouts, power considerations, and module roles
- expand the README with project highlights, setup guidance, and documentation links

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d0cb097ff483258eb6ae47ca61ad91