### PR TITLE
Remove speed sensor documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ studying each subsystem in isolation.
   environment sensing, allowing the Wi-Fi hub to focus on networking and
   failsafe logic.
 - **Telemetry feedback** – Sensor data is forwarded to the controller and shown
-  on a TFT display, while a standalone speed monitoring sketch visualises motion
-  on an OLED.
+  on a TFT display.
 
 ## Repository Layout
 | File / Folder | Purpose |
@@ -24,7 +23,6 @@ studying each subsystem in isolation.
 | `MCUwifiSimplified.ino` | ESP32 access-point firmware that bridges Wi-Fi to dual UARTs. |
 | `VehicleManager.ino` | Arduino Nano sketch controlling servos, ESC, horn, and lights. |
 | `SensorManager.ino` | Arduino Nano sketch that streams environment telemetry (currently simulated). |
-| `SpeedSensor.ino` | Optional module measuring wheel speed and distance with a hall sensor. |
 | `docs/communication_protocol.md` | Detailed description of command packets and telemetry framing. |
 | `docs/wiring_schema.md` | Pinout reference and wiring guidelines for all modules. |
 
@@ -36,10 +34,9 @@ studying each subsystem in isolation.
      supply servos/ESC current peaks.
 2. **Flash the firmware**
    - Upload each sketch to its respective board (controller ESP32, robot ESP32,
-     Vehicle Manager Nano, Sensor Manager Nano, and optional speed sensor
-     module).
+     Vehicle Manager Nano, and Sensor Manager Nano).
    - Confirm serial baud rates match the sketches (115200 bps for all inter-board
-     links except the speed sensor at 9600 bps).
+     links).
 3. **Establish the network link**
    - Power the robot ESP32 to start the `Robot_AP` access point (password
      `12345678`).
@@ -49,8 +46,6 @@ studying each subsystem in isolation.
    - Watch the Vehicle Manager servos/ESC respond to joystick inputs.
    - Check that telemetry values appear on the controller TFT, confirming the
      Sensor Manager and Wi-Fi bridge are operating.
-   - (Optional) Monitor averaged speed and distance on the OLED if the speed
-     sensor module is installed.
 
 ## Communication and Telemetry
 The command string format, failsafe behaviour, and telemetry framing are fully

--- a/docs/communication_protocol.md
+++ b/docs/communication_protocol.md
@@ -15,9 +15,6 @@ Wi-Fi and serial links:
 4. **Sensor Manager (Arduino Nano)** – Streams distance, temperature, and
    humidity readings to the Wi-Fi hub, which are then sent to the controller.
 
-An optional **Speed Sensor module** (standalone sketch) reports average speed and
-travelled distance on an OLED display and the serial monitor.
-
 ```
 [Controller ESP32] ⇄ Wi-Fi UDP ⇄ [Robot ESP32] ⇄ UART1 ⇄ [Sensor Nano]
                                             ⇓ UART2
@@ -97,14 +94,3 @@ following order:
 
 Values are labelled and units appended (`cm`, `C`, `%`).
 
-## Speed Sensor Telemetry (Standalone)
-The `SpeedSensor.ino` sketch samples a hall-effect wheel sensor on digital pin 2
-and reports:
-
-- Raw and averaged linear speed (in m/s) on the serial monitor.
-- Total distance travelled (in metres).
-- Averaged speed and distance on a 128×64 OLED display addressed at I²C `0x3C`.
-
-The distance per pulse is set to 4.04 cm (derived from the measured wheel
-circumference and magnet configuration). A rolling average of the last five
-samples smooths the reported speed.

--- a/docs/wiring_schema.md
+++ b/docs/wiring_schema.md
@@ -83,17 +83,3 @@ Adapt pin choices to match the actual sensors you deploy, ensuring the telemetry
 format documented in [`communication_protocol.md`](communication_protocol.md) is
 maintained.
 
-## Speed Sensor Module (Standalone)
-If you deploy the speed sensor monitor (`SpeedSensor.ino`), wire the components
-as follows:
-
-| Function               | Arduino Pin | Notes |
-|------------------------|-------------|-------|
-| Hall effect sensor     | D2          | Uses an interrupt on the rising edge. Enable pull-up if the sensor is open drain. |
-| OLED SDA               | A4 (SDA)    | Default I²C data line on Arduino Uno/Nano. |
-| OLED SCL               | A5 (SCL)    | Default I²C clock line. |
-| OLED VCC / GND         | 5 V, GND    | The SSD1306 module typically accepts 3.3–5 V. |
-
-Mount four magnets evenly around the drivetrain shaft so the sensor registers
-four pulses per revolution. Adjust the `distancePerPulse` constant if your wheel
-circumference or magnet count differs from the example configuration.


### PR DESCRIPTION
## Summary
- remove the SpeedSensor.ino entry and setup instructions from the top-level README
- delete the standalone speed sensor sections from the communication protocol and wiring schema guides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d24635b8308325984479c4899bedfe